### PR TITLE
Change to pass the ansbile playbook syntax check

### DIFF
--- a/chicagolug.yml
+++ b/chicagolug.yml
@@ -116,8 +116,3 @@
     - nginx
     - chicago-lug-nginx-config
     - pelican
-
-- hosts: raxmg
-  remote_user: root
-  roles: 
-    - ansible-debian-mediagoblin


### PR DESCRIPTION
Right now this playbook can not pass a basic ansible-playbook --syntax-check so this is a little work around until more code can be added and until Jenkins can start checking code automatically.